### PR TITLE
v1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+The complete changelog for the Costs to Expect Website, follows the format defined at https://keepachangelog.com/en/1.0.0/
+
+## [v1.10.1] - 2019-08-31
+
+### Changed
+- We have updated the CHANGELOG and added links to the GitHub repositories for the Costs to Expect Website and API.
+
+## [v1.10.0] - 2019-08-27
+
+### Added 
+- We have added a README with a brief overview and set up instructions.
+- We have added Google Analytics to the website, GPDR friendly.
+- We have added a privacy policy page.
+
+### Changed
+- New content for the Changelog content page ready for the Open Source release.
+- New content for the About content page ready for the Open Source release.
+
+### Removed
+- We have removed the meta details for each release, they are no longer necessary now that the website has been Open Sourced.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The complete changelog for the Costs to Expect Website, follows the format defin
 
 ## [v1.10.1] - 2019-08-31
 
+### Added 
+- We have added a CHANGELOG file to the repo, it will contain full details of all changes post v1.10.0. 
+
 ### Changed
 - We have updated the CHANGELOG and added links to the GitHub repositories for the Costs to Expect Website and API.
 

--- a/config/web/app.php
+++ b/config/web/app.php
@@ -3,8 +3,8 @@
 declare(strict_types=1);
 
 return [
-    'release' => 'v1.10.0',
-    'date' => '27th August 2019',
+    'release' => 'v1.10.1',
+    'date' => '31st August 2019',
     'copyright' => 'G3D Development Limited 2018 - ' . date('Y'),
     'copyright_url' => 'https://www.g3d-development.com',
     'api-link' => 'https://api.costs-to-expect.com',

--- a/resources/views/changelog.blade.php
+++ b/resources/views/changelog.blade.php
@@ -6,16 +6,30 @@
     <div class="col-12">
         <h2>Releases</h2>
 
-        <p>The changelog for the Costs to Expect website, we try not to say
-            <code>bug fixes and improvements</code>, we may on occasion not fully detail a
-            change or fix if we don't feel it is necessary, however, as the website is Open Source
-            you can simply head on over to GitHub.</p>
+        <p>This is the changelog for the Costs to Expect Website. In our updates
+            we try not to say <code>bug fixes and improvements</code>, however,
+            we may on occasion list slightly less detail here
+            if we don't feel it is necessary to mention a change.
+            </p>
+        <p>This website is Open Source so you can simply head on over to
+            <a href="https://github.com/costs-to-expect/website/blob/master/CHANGELOG.md">GitHub</a>
+            to see everything.</p>
 
-        <p>The Website consumes the Costs to Expect API, its changelog can be found over on
-            <a href="https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md">GitHub</a>,
-            the API changelog details every change, the API is Open Source.</p>
+        <p>The Costs to Expect Website consumes the Costs to Expect API, the full changelog for
+            the Costs to Expect API can also be found on
+            <a href="https://github.com/costs-to-expect/api/blob/master/CHANGELOG.md">GitHub</a>, both
+            products are Open Source.</p>
 
         <hr />
+
+        <h2>[v1.10.1] - 31st August 2019</h2>
+
+        <h3>Changed</h3>
+
+        <ul>
+            <li>We have updated the CHANGELOG and added links to the GitHub repositories for the
+            Costs to Expect Website and API.</li>
+        </ul>
 
         <h2>[v1.10.0] - 27th August 2019 (Open Source release)</h2>
 

--- a/resources/views/changelog.blade.php
+++ b/resources/views/changelog.blade.php
@@ -24,6 +24,12 @@
 
         <h2>[v1.10.1] - 31st August 2019</h2>
 
+        <h3>Added</h3>
+
+        <ul>
+            <li>We have added a CHANGELOG file to the repo, it will contain full details of all changes post v1.10.0.</li>
+        </ul>
+
         <h3>Changed</h3>
 
         <ul>


### PR DESCRIPTION
### Added 
- We have added a CHANGELOG file to the repo, it will contain full details of all changes post v1.10.0. 

### Changed
- We have updated the CHANGELOG and added links to the GitHub repositories for the Costs to Expect Website and API.