### PR TITLE
API, version 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 The complete changelog for the Costs to Expect Website, follows the format defined at https://keepachangelog.com/en/1.0.0/
-## [v1.10.2] - 2019-09-15
+## [v1.10.2] - 2019-09-17
 
 ### Changed
 - We have added a `version` property to the `Uri` class so it will be simpler to switch to a newer version of the Costs to Expect API in the future.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 The complete changelog for the Costs to Expect Website, follows the format defined at https://keepachangelog.com/en/1.0.0/
+## [v1.10.2] - 2019-09-15
+
+### Changed
+- We have added a `version` property to the `Uri` class so it will be simpler to switch to a newer version of the Costs to Expect API in the future.
+- The Costs to Expect website consumes data from v2 of the Costs to Expect API.
+- The website displays a warning if the root of the API returns a 404.
 
 ## [v1.10.1] - 2019-08-31
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -34,12 +34,12 @@ class AppServiceProvider extends ServiceProvider
 
         Http::getInstance()
             ->public()
-            ->get('/v1', false, [__CLASS__, __METHOD__]);
+            ->get('/v2', false, [__CLASS__, __METHOD__]);
 
         View()->composer(['layouts.default'], function($view) {
             $view->with(
                 'api_status',
-                (Http::getInstance()->previousRequestStatusCode() === 503 ? false : true)
+                Http::getInstance()->previousRequestStatusCode()
             );
         });
     }

--- a/app/Request/Http.php
+++ b/app/Request/Http.php
@@ -90,7 +90,7 @@ class Http
     {
         try {
             $response = self::$client->post(
-                '/v1/request/error-log',
+                '/v2/request/error-log',
                 [
                     RequestOptions::JSON => [
                         'method' => $method,

--- a/app/Request/Uri.php
+++ b/app/Request/Uri.php
@@ -11,7 +11,7 @@ namespace App\Request;
 class Uri
 {
     private static $resource_type = 'd185Q15grY';
-    private static $version = 'v1';
+    private static $version = 'v2';
 
     /**
      * @param string $child_id

--- a/app/Request/Uri.php
+++ b/app/Request/Uri.php
@@ -11,6 +11,7 @@ namespace App\Request;
 class Uri
 {
     private static $resource_type = 'd185Q15grY';
+    private static $version = 'v1';
 
     /**
      * @param string $child_id
@@ -18,7 +19,7 @@ class Uri
      */
     public static function summaryExpenses(string $child_id): string
     {
-        return '/v1/summary/resource-types/' . self::$resource_type .
+        return '/' . self::$version . '/summary/resource-types/' . self::$resource_type .
             '/resources/' . $child_id . '/items';
     }
 
@@ -28,7 +29,7 @@ class Uri
      */
     public static function summaryExpensesForCurrentYear(string $child_id): string
     {
-        return '/v1/summary/resource-types/' . self::$resource_type .
+        return '/' . self::$version . '/summary/resource-types/' . self::$resource_type .
             '/resources/' . $child_id . '/items?year=' . date('Y');
     }
 
@@ -38,7 +39,7 @@ class Uri
      */
     public static function summaryExpensesGroupByCategory(string $child_id): string
     {
-        return '/v1/summary/resource-types/' . self::$resource_type .
+        return '/' . self::$version . '/summary/resource-types/' . self::$resource_type .
             '/resources/' . $child_id . '/items?categories=true';
     }
 
@@ -53,7 +54,7 @@ class Uri
         string $category_id
     ): string
     {
-        return '/v1/summary/resource-types/' . self::$resource_type .
+        return '/' . self::$version . '/summary/resource-types/' . self::$resource_type .
             '/resources/' . $child_id . '/items?category=' . $category_id .
             '&subcategories=true';
     }
@@ -64,7 +65,7 @@ class Uri
      */
     public static function summaryExpensesAnnual(string $child_id): string
     {
-        return '/v1/summary/resource-types/' . self::$resource_type .
+        return '/' . self::$version . '/summary/resource-types/' . self::$resource_type .
             '/resources/' . $child_id . '/items?years=true';
     }
 
@@ -76,7 +77,7 @@ class Uri
      */
     public static function summaryExpensesMonthly(string $child_id, int $year): string
     {
-        return '/v1/summary/resource-types/' . self::$resource_type .
+        return '/' . self::$version . '/summary/resource-types/' . self::$resource_type .
             '/resources/' . $child_id . '/items?year=' . $year . '&months=true';
     }
 
@@ -93,7 +94,7 @@ class Uri
         bool $include_subcategories = false
     ): string
     {
-        $uri = '/v1/resource-types/' . self::$resource_type . '/items?limit=' . $limit;
+        $uri = '/' . self::$version . '/resource-types/' . self::$resource_type . '/items?limit=' . $limit;
 
         if ($include_categories === true) {
             $uri .= '&include-categories=true';
@@ -133,7 +134,7 @@ class Uri
         bool $include_subcategories = false
     ): string
     {
-        $uri = '/v1/resource-types/' . self::$resource_type . '/resources/' .
+        $uri = '/' . self::$version . '/resource-types/' . self::$resource_type . '/resources/' .
             $child_id . '/items?offset=' . $offset . '&limit=' . $limit;
 
         if ($category !== null) {
@@ -186,7 +187,7 @@ class Uri
         string $term = null
     ): string
     {
-        $uri = '/v1/summary/resource-types/' . self::$resource_type . '/resources/' .
+        $uri = '/' . self::$version . '/summary/resource-types/' . self::$resource_type . '/resources/' .
             $child_id . '/items';
 
         $params = [];
@@ -236,7 +237,7 @@ class Uri
         bool $include_subcategories = false
     ): string
     {
-        $uri = '/v1/resource-types/' . self::$resource_type . '/resources/' .
+        $uri = '/' . self::$version . '/resource-types/' . self::$resource_type . '/resources/' .
             $child_id . '/items?limit=' . $limit;
 
         if ($include_categories === true) {
@@ -267,7 +268,7 @@ class Uri
         bool $include_subcategories = false
     ): string
     {
-        $uri = '/v1/resource-types/' . self::$resource_type . '/resources/' .
+        $uri = '/' . self::$version . '/resource-types/' . self::$resource_type . '/resources/' .
             $child_id . '/items?category=' . $category_id . '&limit=' . $limit;
 
         if ($include_categories === true) {
@@ -298,7 +299,7 @@ class Uri
         bool $include_subcategories = false
     ): string
     {
-        $uri = '/v1/resource-types/' . self::$resource_type . '/resources/' .
+        $uri = '/' . self::$version . '/resource-types/' . self::$resource_type . '/resources/' .
             $child_id . '/items?year=' . $year . '&limit=' . $limit;
 
         if ($include_categories === true) {
@@ -331,7 +332,7 @@ class Uri
         bool $include_subcategories = false
     ): string
     {
-        $uri = '/v1/resource-types/' . self::$resource_type . '/resources/' .
+        $uri = '/' . self::$version . '/resource-types/' . self::$resource_type . '/resources/' .
             $child_id . '/items?year=' . $year . '&month=' . $month . '&limit=' . $limit;
 
         if ($include_categories === true) {
@@ -364,7 +365,7 @@ class Uri
         bool $include_subcategories = false
     ): string
     {
-        $uri = '/v1/resource-types/' . self::$resource_type . '/resources/' .
+        $uri = '/' . self::$version . '/resource-types/' . self::$resource_type . '/resources/' .
             $child_id . '/items?category=' . $category_id . '&subcategory=' .
             $subcategory_id . '&limit=' . $limit;
 
@@ -389,7 +390,7 @@ class Uri
         string $child_id,
         string $category_id): string
     {
-        $uri = '/v1/resource-types/' . self::$resource_type . '/resources/' .
+        $uri = '/' . self::$version . '/resource-types/' . self::$resource_type . '/resources/' .
             $child_id . '/items?category='. $category_id .
             '&sort=actualised_total:desc&limit=1';
 
@@ -404,7 +405,7 @@ class Uri
      */
     public static function subcategory(string $category_id, string $subcategory_id): string
     {
-        return '/v1/categories/' . $category_id . '/subcategories/' .
+        return '/' . self::$version . '/categories/' . $category_id . '/subcategories/' .
             $subcategory_id;
     }
 
@@ -415,6 +416,6 @@ class Uri
      */
     public static function subcategories(string $category_id): string
     {
-        return '/v1/categories/' . $category_id . '/subcategories/';
+        return '/' . self::$version . '/categories/' . $category_id . '/subcategories/';
     }
 }

--- a/config/web/app.php
+++ b/config/web/app.php
@@ -3,8 +3,8 @@
 declare(strict_types=1);
 
 return [
-    'release' => 'v1.10.1',
-    'date' => '31st August 2019',
+    'release' => 'v1.10.2',
+    'date' => '15th September 2019',
     'copyright' => 'G3D Development Limited 2018 - ' . date('Y'),
     'copyright_url' => 'https://www.g3d-development.com',
     'api-link' => 'https://api.costs-to-expect.com',

--- a/config/web/app.php
+++ b/config/web/app.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 return [
     'release' => 'v1.10.2',
-    'date' => '15th September 2019',
+    'date' => '17th September 2019',
     'copyright' => 'G3D Development Limited 2018 - ' . date('Y'),
     'copyright_url' => 'https://www.g3d-development.com',
     'api-link' => 'https://api.costs-to-expect.com',

--- a/resources/views/changelog.blade.php
+++ b/resources/views/changelog.blade.php
@@ -22,7 +22,7 @@
 
         <hr />
 
-        <h2>[v1.10.2] - 15th September 2019</h2>
+        <h2>[v1.10.2] - 17th September 2019</h2>
 
         <h3>Changed</h3>
 

--- a/resources/views/changelog.blade.php
+++ b/resources/views/changelog.blade.php
@@ -22,6 +22,16 @@
 
         <hr />
 
+        <h2>[v1.10.2] - 15th September 2019</h2>
+
+        <h3>Changed</h3>
+
+        <ul>
+            <li>We have added a `version` property to the `Uri` class so it will be simpler to switch to a newer version of the Costs to Expect API in the future.</li>
+            <li>The Costs to Expect website consumes data from v2 of the Costs to Expect API.</li>
+            <li>The website displays a warning if the root of the API returns a 404.</li>
+        </ul>
+
         <h2>[v1.10.1] - 31st August 2019</h2>
 
         <h3>Added</h3>

--- a/resources/views/layouts/default.blade.php
+++ b/resources/views/layouts/default.blade.php
@@ -117,13 +117,26 @@
                         </div>
                     </div>
 
-                    @if ($api_status === false)
+                    @if ($api_status === 503)
                     <div class="row mb-3">
                         <div class="col-12">
                             <div class="alert alert-warning" role="alert">
                                 The Costs to Expect API is temporarily not available, there is a better than zero chance
                                 that the API is down for maintenance, please try again later.<br />
                                 If the error persists please reach out to us on
+                                <a href="https://twitter.com/coststoexpect">Twitter</a>
+                            </div>
+                        </div>
+                    </div>
+                    @endif
+
+                    @if ($api_status === 404)
+                    <div class="row mb-3">
+                        <div class="col-12">
+                            <div class="alert alert-warning" role="alert">
+                                The Costs to Expect API is not available, as it is returning a 404 it is likely
+                                we are performing an upgrade..<br />
+                                If the error persists for more than a few hours, please reach out to us on
                                 <a href="https://twitter.com/coststoexpect">Twitter</a>
                             </div>
                         </div>


### PR DESCRIPTION
- We have added a `version` property to the `Uri` class so it will be simpler to switch to a newer version of the Costs to Expect API in the future. 
- The Costs to Expect website consumes data from v2 of the Costs to Expect API. 
- The website displays a warning if the root of the API returns a 404. 



