### PR TITLE
v1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The complete changelog for the Costs to Expect Website, our changelog follows the format defined at https://keepachangelog.com/en/1.0.0/
 
+## [v1.13.0] - 2020-09-17
+### Added 
+- We have updated the Website to use the latest version of the Costs to Expect API, v2.14.0.
+
+### Changed
+- We return additional information for failed API requests.
+
 ## [v1.12.7] - 2020-06-19
 ### Changed
 - We have switched to Redis for our caching.

--- a/app/Http/Controllers/ChildController.php
+++ b/app/Http/Controllers/ChildController.php
@@ -250,11 +250,22 @@ class ChildController extends BaseController
                 $filter_parameters['term']
             );
 
-            if (
-                $filtered_summary !== null &&
-                array_key_exists('total', $filtered_summary) === true
-            ) {
-                $filtered_summary = $filtered_summary['total'];
+            if ($filtered_summary !== null) {
+                if (array_key_exists('subtotals', $filtered_summary) === true) {
+                    foreach ($filtered_summary['subtotals'] as $subtotal) {
+                        if ($subtotal['currency']['code'] === 'GBP') {
+                            $filtered_summary = $subtotal['subtotal'];
+                            break;
+                        }
+                    }
+                } else {
+                    foreach ($filtered_summary as $subtotal) {
+                        if (array_key_exists('subtotal', $subtotal) && $subtotal['currency']['code'] === 'GBP') {
+                            $filtered_summary = $subtotal['subtotal'];
+                            break;
+                        }
+                    }
+                }
             }
         }
 

--- a/app/Http/Controllers/ChildController.php
+++ b/app/Http/Controllers/ChildController.php
@@ -369,7 +369,21 @@ class ChildController extends BaseController
         $categories_summary_data = $overview_model->categoriesSummary($child_model->id());
         $categories_summary = $categories_summary_data['summary'];
 
-        $subcategories_summary = $category_model->subcategorySummary($child_model->id(), $category_model->id());
+        $subcategories_summary_data = $category_model->subcategorySummary($child_model->id(), $category_model->id());
+
+        $subcategories_summary = [];
+
+        foreach ($subcategories_summary_data as $subcategory) {
+            $subcategory['total'] = 0;
+            foreach ($subcategory['subtotals'] as $subtotal) {
+                if ($subtotal['currency']['code'] === 'GBP') {
+                    $subcategory['total'] = $subtotal['subtotal'];
+                    break;
+                }
+            }
+
+            $subcategories_summary[] = $subcategory;
+        }
 
         $recent_expenses_data = $expense_model->recentExpensesByCategory($child_model->id(), $category_model->id());
         $recent_expenses = $recent_expenses_data['expenses'];
@@ -443,24 +457,19 @@ class ChildController extends BaseController
         $categories_summary_data = $overview_model->categoriesSummary($child_model->id());
         $categories_summary = $categories_summary_data['summary'];
 
-        $subcategories_summary = $category_model->subcategorySummary($child_model->id(), $category_model->id());
+        $subcategories_summary_data = $category_model->subcategorySummary($child_model->id(), $category_model->id());
+        $subcategories_summary = [];
 
-        $exists = false;
-        foreach ($subcategories_summary as $sub) {
-            if ($sub['id'] === $subcategory_id) {
-                $exists = true;
-                continue;
+        foreach ($subcategories_summary_data as $subcategory) {
+            $subcategory['total'] = 0;
+            foreach ($subcategory['subtotals'] as $subtotal) {
+                if ($subtotal['currency']['code'] === 'GBP') {
+                    $subcategory['total'] = $subtotal['subtotal'];
+                    break;
+                }
             }
-        }
 
-        if ($exists === false) {
-            return redirect()->action(
-                'ChildController@category',
-                [
-                    'child' => $child,
-                    'category_uri' => $category_uri
-                ]
-            );
+            $subcategories_summary[] = $subcategory;
         }
 
         $subcategory = $subcategory_model->subcategory($category_model->id(), $subcategory_id);
@@ -541,7 +550,20 @@ class ChildController extends BaseController
         $child_overview = $this->childOverview($child_model, $overview_model);
 
         $annual_summary = $annual_model->annualSummary($child_model->id(), false);
-        $monthly_summary = $annual_model->monthlySummary($child_model->id(), (int) $year);
+        $monthly_summary_data = $annual_model->monthlySummary($child_model->id(), (int) $year);
+        $monthly_summary = [];
+
+        foreach ($monthly_summary_data as $month) {
+            $month['total'] = 0;
+            foreach ($month['subtotals'] as $subtotal) {
+                if ($subtotal['currency']['code'] === 'GBP') {
+                    $month['total'] = $subtotal['subtotal'];
+                    break;
+                }
+            }
+
+            $monthly_summary[] = $month;
+        }
 
         $recent_expenses_data = $expense_model->recentExpensesByYear(
             $child_model->id(),
@@ -607,7 +629,20 @@ class ChildController extends BaseController
         $child_overview = $this->childOverview($child_model, $overview_model);
 
         $annual_summary = $annual_model->annualSummary($child_model->id(), false);
-        $monthly_summary = $annual_model->monthlySummary($child_model->id(), (int) $year);
+        $monthly_summary_data = $annual_model->monthlySummary($child_model->id(), (int) $year);
+        $monthly_summary = [];
+
+        foreach ($monthly_summary_data as $month_subtotals) {
+            $month_subtotals['total'] = 0;
+            foreach ($month_subtotals['subtotals'] as $subtotal) {
+                if ($subtotal['currency']['code'] === 'GBP') {
+                    $month_subtotals['total'] = $subtotal['subtotal'];
+                    break;
+                }
+            }
+
+            $monthly_summary[] = $month_subtotals;
+        }
 
         $recent_expenses_data = $expense_model->recentExpensesByMonth(
             $child_model->id(),

--- a/app/Models/Child.php
+++ b/app/Models/Child.php
@@ -70,9 +70,14 @@ abstract class Child
                 'total' => 0.00
             ];
 
-            if ($response !== null && array_key_exists('total', $response) === true) {
-                    $this->total['total'] = $response['total'];
-                    $this->total_populated = true;
+            if ($response !== null) {
+                foreach ($response as $subtotal) {
+                    if ($subtotal['currency']['code'] === 'GBP') {
+                        $this->total['total'] = $subtotal['subtotal'];
+                        $this->total_populated = true;
+                        break;
+                    }
+                }
             }
         }
 
@@ -125,9 +130,14 @@ abstract class Child
 
             $this->total_current_year = 0.00;
 
-            if ($response !== null && array_key_exists('total', $response) === true) {
-                $this->total_current_year = (float) $response['total'];
-                $this->total_current_year_populated = true;
+            if ($response !== null && array_key_exists('subtotals', $response) === true) {
+                foreach ($response['subtotals'] as $subtotal) {
+                    if ($subtotal['currency']['code'] === 'GBP') {
+                        $this->total_current_year = (float) $subtotal['subtotal'];
+                        $this->total_current_year_populated = true;
+                        break;
+                    }
+                }
             }
         }
 

--- a/app/Models/Child/Annual.php
+++ b/app/Models/Child/Annual.php
@@ -37,7 +37,7 @@ class Annual
             Api::setCalledURI('Expenses summary by year', Api::lastUri());
 
             if ($partial === true) {
-                for ($i = intval(date('Y')); $i > intval(date('Y')) - 3; $i--) {
+                for ($i = (int) date('Y'); $i > (int) date('Y') - 3; $i--) {
                     $this->summary[$i] = [
                         'year' => $i,
                         'total' => 0.00
@@ -47,7 +47,12 @@ class Annual
                 if ($response !== null) {
                     foreach ($response as $year) {
                         if (array_key_exists($year['year'], $this->summary) === true) {
-                            $this->summary[$year['year']]['total'] = (float) $year['total'];
+                            foreach ($year['subtotals'] as $subtotal) {
+                                if ($subtotal['currency']['code'] === 'GBP') {
+                                    $this->summary[$year['year']]['total'] = (float) $subtotal['subtotal'];
+                                    break;
+                                }
+                            }
                         }
                     }
                 }
@@ -55,9 +60,15 @@ class Annual
                 if ($response !== null) {
                     foreach ($response as $year) {
                         $this->summary[$year['year']] = [
-                            'year' => $year['year'],
-                            'total' => (float) $year['total']
+                            'year' => $year['year']
                         ];
+
+                        foreach ($year['subtotals'] as $subtotal) {
+                            if ($subtotal['currency']['code'] === 'GBP') {
+                                $this->summary[$year['year']]['total'] = (float) $subtotal['subtotal'];
+                                break;
+                            }
+                        }
                     }
                     $this->summary = array_reverse($this->summary);
                 } else {

--- a/app/Models/Child/Overview.php
+++ b/app/Models/Child/Overview.php
@@ -190,7 +190,12 @@ class Overview
                 $this->setCategoriesSummaryData();
 
                 foreach ($response as $category) {
-                    $this->summary[$category['id']]['total'] = $category['total'];
+                    foreach ($category['subtotals'] as $subtotal) {
+                        if ($subtotal['currency']['code'] === 'GBP') {
+                            $this->summary[$category['id']]['total'] = $subtotal['subtotal'];
+                            break;
+                        }
+                    }
                 }
 
                 $total = $this->summary['98WLap7Bx3']['total'] +

--- a/app/Request/Api.php
+++ b/app/Request/Api.php
@@ -60,9 +60,9 @@ class Api
 
         if ($response !== null) {
             return $response;
-        } else {
-            return null;
         }
+
+        return null;
     }
 
     /**
@@ -414,7 +414,7 @@ class Api
         if ($cached === null) {
             $response = Http::getInstance()
                 ->public()
-                ->get($uri, true, [__CLASS__, __METHOD__]);
+                ->get($uri, true, [__CLASS__, __METHOD__, request()->getRequestUri()]);
 
             if ($response !== null) {
                 $cache->put(
@@ -428,9 +428,9 @@ class Api
             }
 
             return null;
-        } else {
-            Http::getInstance()->setHeaders($cached['headers']);
-            return $cached['body'];
         }
+
+        Http::getInstance()->setHeaders($cached['headers']);
+        return $cached['body'];
     }
 }

--- a/config/web/app.php
+++ b/config/web/app.php
@@ -3,8 +3,8 @@
 declare(strict_types=1);
 
 return [
-    'release' => 'v1.12.6',
-    'date' => '7th June 2020',
+    'release' => 'v1.13.0',
+    'date' => '27th September 2020',
     'copyright' => 'Dean Blackborough 2018 - ' . date('Y'),
     'copyright_url' => 'https://www.deanblackborough.com',
     'api-link' => 'https://api.costs-to-expect.com',

--- a/resources/views/changelog.blade.php
+++ b/resources/views/changelog.blade.php
@@ -22,6 +22,20 @@
 
         <hr />
 
+        <h2>[v1.13.0] - 27th Sepetember 2020</h2>
+
+        <h3>Added</h3>
+
+        <ul>
+            <li>We have updated the Website to use the latest version of the Costs to Expect API, v2.14.0.</li>
+        </ul>
+
+        <h3>Changed</h3>
+
+        <ul>
+            <li>We return additional information for failed API requests.</li>
+        </ul>
+
         <h2>[v1.12.7] - 19th June 2020</h2>
 
         <h3>Changed</h3>


### PR DESCRIPTION
### Added 
- We have updated the Website to use the latest version of the Costs to Expect API, v2.14.0.

### Changed
- We return additional information for failed API requests.